### PR TITLE
feat: use client's timezone

### DIFF
--- a/isitwet-app/src/components/utils/AppNavbar.js
+++ b/isitwet-app/src/components/utils/AppNavbar.js
@@ -2,17 +2,11 @@ import React, { Component } from 'react';
 import { Navbar, NavbarBrand } from 'reactstrap';
 import { Link } from 'react-router-dom';
 
+import ToggleButton from './ToggleButton';
+
 export default class AppNavbar extends Component {
     constructor(props) {
         super(props);
-        this.state = { isOpen: false };
-        this.toggle = this.toggle.bind(this);
-    }
-
-    toggle() {
-        this.setState({
-            isOpen: !this.state.isOpen
-        });
     }
 
     render() {

--- a/isitwet-app/src/components/weather/WeatherDetail.js
+++ b/isitwet-app/src/components/weather/WeatherDetail.js
@@ -26,13 +26,16 @@ class WeatherDetail extends Component {
     }
 
     async componentDidMount() {
-        const weatherDetail = await (await fetch(`/api/v1/weather/${this.props.match.params.id}`, {
-            method: 'GET',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            }
-        })).json();
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const weatherDetail = await (
+            await fetch(`/api/v1/weather/${this.props.match.params.id}?timezone=${timezone}`, {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                }
+            })
+        ).json();
         const location = await (await fetch(`/api/v1/locations/${this.props.match.params.id}`)).json();
         this.setState({
             weatherItem: weatherDetail,

--- a/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/controller/WeatherController.java
+++ b/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/controller/WeatherController.java
@@ -34,9 +34,10 @@ public class WeatherController {
     @ApiResponse(description = "Get weather for a specific longitude/latitude.", responseCode = "200")
     public ResponseEntity<WeatherDTO> getWeather(
             @RequestParam(required = true) Float longitude,
-            @RequestParam(required = true) Float latitude
+            @RequestParam(required = true) Float latitude,
+            @RequestParam(required = false, defaultValue = "GMT") String timezone
         ) {
-        var response = this.weatherService.getWeather(longitude, latitude);
+        var response = this.weatherService.getWeather(longitude, latitude, timezone);
         return ResponseEntity.ok(response);
     }
     
@@ -45,11 +46,12 @@ public class WeatherController {
     @GetMapping("/{id}")
     @ApiResponse(description = "Get weather for a specific location.", responseCode = "200")
     public ResponseEntity<WeatherDTO> getWeather(
-            @PathVariable Long id
+            @PathVariable Long id,
+            @RequestParam(required = false, defaultValue = "GMT") String timezone
         ) {
         var location = locationRepository.findById(id);
         if (location.isPresent()) {
-            var response = this.weatherService.getWeather(location.get().getLongitude(), location.get().getLatitude());
+            var response = this.weatherService.getWeather(location.get().getLongitude(), location.get().getLatitude(), timezone);
             return ResponseEntity.ok(response);
         }
         return ResponseEntity.badRequest().build();

--- a/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/model/OpenMeteoResult.java
+++ b/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/model/OpenMeteoResult.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import local.jona.isitwet.isitwet.model.format.DurationFormat;
 import local.jona.isitwet.isitwet.model.format.PrecipitationFormat;
-import local.jona.isitwet.isitwet.model.format.PrecipitationFormat;
 import local.jona.isitwet.isitwet.model.format.TemperatureFormat;
 import local.jona.isitwet.isitwet.model.format.TimeFormat;
 import lombok.Data;

--- a/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/service/OpenMeteoClient.java
+++ b/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/service/OpenMeteoClient.java
@@ -29,17 +29,18 @@ public class OpenMeteoClient {
      *
      * @param longitude float.
      * @param latitude float.
+     * @param timezone string.
      *
      * @return OpenMeteoResult instance containing the response from Open-Meteo.
      */
-    public OpenMeteoResult getWeather(Float longitude, Float latitude) {
+    public OpenMeteoResult getWeather(Float longitude, Float latitude, String timezone) {
         var url = this.openMeteoUrl
             + "/forecast?latitude=" + latitude + "&longitude=" + longitude
             + "&daily=temperature_2m_max,temperature_2m_min,sunshine_duration,rain_sum,weather_code,snowfall_sum"
             + "&hourly=temperature_2m,relative_humidity_2m,rain,snowfall,weather_code"
-            + "&timezone=GMT"
             + "&past_days=2"
-            + "&forecast_days=2";
+            + "&forecast_days=2"
+            + "&timezone=" + timezone;
         var request = new HttpEntity<String>("", this.getHeaders());
 
         try {

--- a/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/service/WeatherService.java
+++ b/isitwet-backend/src/main/java/local/jona/isitwet/isitwet/service/WeatherService.java
@@ -16,8 +16,8 @@ public class WeatherService {
     @Autowired
     private OpenMeteoClient openMeteoClient;
 
-    public WeatherDTO getWeather(Float longitude, Float latitude) {
-        var response = this.openMeteoClient.getWeather(longitude, latitude);
+    public WeatherDTO getWeather(Float longitude, Float latitude, String timezone) {
+        var response = this.openMeteoClient.getWeather(longitude, latitude, timezone);
         var result = this.openMeteoResultMapper.openMeteoResultToWeatherDTO(response);
         return result;
     }

--- a/isitwet-backend/src/test/java/local/jona/isitwet/isitwet/service/OpenMeteoClientTests.java
+++ b/isitwet-backend/src/test/java/local/jona/isitwet/isitwet/service/OpenMeteoClientTests.java
@@ -3,7 +3,6 @@ package local.jona.isitwet.isitwet.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,8 +18,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import local.jona.isitwet.isitwet.model.OpenMeteoResult;
-import local.jona.isitwet.isitwet.model.dto.WeatherDTO;
-import local.jona.isitwet.isitwet.model.mapper.OpenMeteoResultMapper;
 
 
 public class OpenMeteoClientTests {
@@ -42,9 +39,9 @@ public class OpenMeteoClientTests {
             + "/forecast?latitude=1.0&longitude=0.5"
             + "&daily=temperature_2m_max,temperature_2m_min,sunshine_duration,rain_sum,weather_code,snowfall_sum"
             + "&hourly=temperature_2m,relative_humidity_2m,rain,snowfall,weather_code"
-            + "&timezone=GMT"
             + "&past_days=2"
-            + "&forecast_days=2";
+            + "&forecast_days=2"
+            + "&timezone=Europe/London";
         var expectedResult = new OpenMeteoResult();
         expectedResult.setLongitude(0.5F);
         expectedResult.setLatitude(1.0F);
@@ -55,7 +52,7 @@ public class OpenMeteoClientTests {
             any(),
             eq(OpenMeteoResult.class)
         )).thenReturn(restResponse);
-        var result = openMeteoClient.getWeather(0.5F, 1.0F);
+        var result = openMeteoClient.getWeather(0.5F, 1.0F, "Europe/London");
         assertEquals(expectedResult, result, "We expect the body of the response to be the result.");
 	}
 
@@ -65,9 +62,9 @@ public class OpenMeteoClientTests {
             + "/forecast?latitude=1.0&longitude=0.5"
             + "&daily=temperature_2m_max,temperature_2m_min,sunshine_duration,rain_sum,weather_code,snowfall_sum"
             + "&hourly=temperature_2m,relative_humidity_2m,rain,snowfall,weather_code"
-            + "&timezone=GMT"
             + "&past_days=2"
-            + "&forecast_days=2";
+            + "&forecast_days=2"
+            + "&timezone=Europe/London";
         var restResponse = new ResponseEntity<OpenMeteoResult>(new OpenMeteoResult(), HttpStatusCode.valueOf(500));
         Mockito.when(restTemplateMock.exchange(
             eq(expectedUrl),
@@ -77,7 +74,7 @@ public class OpenMeteoClientTests {
         )).thenReturn(restResponse);
         // var result = openMeteoClient.getWeather(0.5F, 1.0F);
         assertThrows(HttpClientErrorException.class,
-            () -> openMeteoClient.getWeather(0.5F, 1.0F));
+            () -> openMeteoClient.getWeather(0.5F, 1.0F, "Europe/London"));
 	}
 
 	@Test
@@ -86,17 +83,16 @@ public class OpenMeteoClientTests {
             + "/forecast?latitude=1.0&longitude=0.5"
             + "&daily=temperature_2m_max,temperature_2m_min,sunshine_duration,rain_sum,weather_code,snowfall_sum"
             + "&hourly=temperature_2m,relative_humidity_2m,rain,snowfall,weather_code"
-            + "&timezone=GMT"
             + "&past_days=2"
-            + "&forecast_days=2";
+            + "&forecast_days=2"
+            + "&timezone=Europe/London";
         Mockito.when(restTemplateMock.exchange(
             eq(expectedUrl),
             eq(HttpMethod.GET),
             any(),
             eq(OpenMeteoResult.class)
         )).thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(300)));
-        // var result = openMeteoClient.getWeather(0.5F, 1.0F);
         assertThrows(HttpClientErrorException.class,
-            () -> openMeteoClient.getWeather(0.5F, 1.0F));
+            () -> openMeteoClient.getWeather(0.5F, 1.0F, "Europe/London"));
 	}
 }

--- a/isitwet-backend/src/test/java/local/jona/isitwet/isitwet/service/WeatherServiceTests.java
+++ b/isitwet-backend/src/test/java/local/jona/isitwet/isitwet/service/WeatherServiceTests.java
@@ -2,6 +2,7 @@ package local.jona.isitwet.isitwet.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyString;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,9 +39,9 @@ public class WeatherServiceTests {
         result.setLatitude(1.0F);
         result.setElevation(150F);
         var endResult = new WeatherDTO();
-        Mockito.when(localClientMock.getWeather(anyFloat(), anyFloat())).thenReturn(result);
+        Mockito.when(localClientMock.getWeather(anyFloat(), anyFloat(), anyString())).thenReturn(result);
         Mockito.when(mapper.openMeteoResultToWeatherDTO(result)).thenReturn(endResult);
-        var weatherDTO = weatherService.getWeather(0.5F, 1.0F);
+        var weatherDTO = weatherService.getWeather(0.5F, 1.0F, "Europe/London");
         assertEquals(endResult, weatherDTO, "We expect the output of the mapper as end result.");
 	}  
 }


### PR DESCRIPTION
- Backend: timezone is a request parameter for weather endpoints.
- Frontend: client's timezone is passed to the backend.
- Next steps: maybe use timezone of the location rather than timezone of the client ?